### PR TITLE
Fix gradient orientation for color effects

### DIFF
--- a/colors/horizontal_rainbow_effect.py
+++ b/colors/horizontal_rainbow_effect.py
@@ -31,13 +31,13 @@ class HorizontalRainbowEffect(EffectRenderer):
         # Create custom horizontal rainbow colormap
         self.cmap = LinearSegmentedColormap.from_list("horizontal_rainbow", list(zip(positions, colors)))
     
-    def generate_horizontal_rainbow(self, width, height):
+    def generate_horizontal_rainbow(self, height, width):
         """
         Generates a horizontal rainbow gradient.
 
         Args:
-            width (int): Width of the image.
             height (int): Height of the image.
+            width (int): Width of the image.
 
         Returns:
             np.ndarray: RGB image array of the gradient.
@@ -64,7 +64,13 @@ class HorizontalRainbowEffect(EffectRenderer):
         # Check if we need to regenerate the cached surface
         if self.cached_surface is None or self.cached_size != current_size:
             # Generate the horizontal rainbow gradient
-            gradient_rgb = self.generate_horizontal_rainbow(surface_height, surface_width)
+            # Height is expected before width when generating the gradient.
+            # Passing the dimensions in this order ensures the rainbow spans
+            # horizontally across the surface without being rotated.
+            gradient_rgb = self.generate_horizontal_rainbow(
+                surface_height,
+                surface_width,
+            )
             
             # Convert to pygame surface format (0-255, integer)
             gradient_rgb_255 = (gradient_rgb[:, :, :3] * 255).astype(np.uint8) 
@@ -73,5 +79,4 @@ class HorizontalRainbowEffect(EffectRenderer):
             self.cached_surface = pygame.surfarray.make_surface(gradient_rgb_255)
             self.cached_size = current_size
         
-        # Blit the cached gradient onto the main surface
-        surface.blit(self.cached_surface, (0, 0)) 
+        # Blit the cached gradient onto the main surface        surface.blit(self.cached_surface, (0, 0)) 

--- a/colors/radial_gradient_effect.py
+++ b/colors/radial_gradient_effect.py
@@ -32,14 +32,14 @@ class RadialGradientEffect(EffectRenderer):
         # Create custom radial gradient colormap
         self.cmap = LinearSegmentedColormap.from_list("radial_gradient", list(zip(positions, colors)))
     
-    def generate_radial_gradient_circular(self, width, height, zoom_factor=1):
+    def generate_radial_gradient_circular(self, height, width, zoom_factor=1):
         """
         Generates a smooth radial (circular) gradient that fits within the smallest dimension.
         The outermost ring fills the remaining space.
 
         Args:
-            width (int): Width of the image.
             height (int): Height of the image.
+            width (int): Width of the image.
             zoom_factor (float): Zoom factor for the gradient (higher = more zoomed in).
 
         Returns:
@@ -74,7 +74,14 @@ class RadialGradientEffect(EffectRenderer):
         # Check if we need to regenerate the cached surface
         if self.cached_surface is None or self.cached_size != current_size:
             # Generate the circular gradient (static)
-            gradient_rgb = self.generate_radial_gradient_circular(surface_height, surface_width, .65)
+            # Height is expected before width when generating the gradient.
+            # Passing the dimensions in this order keeps the circular
+            # gradient oriented correctly on any aspect ratio.
+            gradient_rgb = self.generate_radial_gradient_circular(
+                surface_height,
+                surface_width,
+                0.65,
+            )
             
             # Convert to pygame surface format (0-255, integer)
             gradient_rgb_255 = (gradient_rgb[:, :, :3] * 255).astype(np.uint8) 
@@ -83,5 +90,4 @@ class RadialGradientEffect(EffectRenderer):
             self.cached_surface = pygame.surfarray.make_surface(gradient_rgb_255)
             self.cached_size = current_size
         
-        # Blit the cached gradient onto the main surface
-        surface.blit(self.cached_surface, (0, 0)) 
+        # Blit the cached gradient onto the main surface        surface.blit(self.cached_surface, (0, 0)) 


### PR DESCRIPTION
## Summary
- fix parameter order when generating gradients so the effects are oriented correctly

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686dcb4519fc8322bbe9774ff1afa2d0